### PR TITLE
Fix feedback implementation 154648234

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bright Events
 
-![travis build](https://travis-ci.org/mirr254/Bright-Events.svg?branch=development) [![Coverage Status](https://coveralls.io/repos/github/mirr254/Bright-Events/badge.svg?branch=development)](https://coveralls.io/github/mirr254/Bright-Events?branch=development)
+![travis build](https://travis-ci.org/mirr254/Bright-Events.svg?branch=development) [![Coverage Status](https://coveralls.io/repos/github/mirr254/Bright-Events/badge.svg?branch=development)](https://coveralls.io/github/mirr254/Bright-Events?branch=development) [![Maintainability](https://api.codeclimate.com/v1/badges/113acdcc6ca3deff6f20/maintainability)](https://codeclimate.com/github/mirr254/Bright-Events/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/113acdcc6ca3deff6f20/test_coverage)](https://codeclimate.com/github/mirr254/Bright-Events/test_coverage)
 
 ## Description
 Bright events provides a platform for event organizers to create and manage different types of events while making them easily accessible to target markets.

--- a/app/auth_blueprint/views.py
+++ b/app/auth_blueprint/views.py
@@ -46,6 +46,8 @@ def register():
         return jsonify({"Hey":"Username must be included"}),403
     if password is None: #password must be included
         return jsonify({"Hey":"Password must be included"}),403
+    if len(password) < 8:
+        return jsonify({'Sorry', 'Password lenth must be more than 8 characters'}),403
     #check correct emai
     bad_email = re.match('^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$', email)    
     if bad_email == None:

--- a/app/auth_blueprint/views.py
+++ b/app/auth_blueprint/views.py
@@ -47,7 +47,7 @@ def register():
     if password is None: #password must be included
         return jsonify({"Hey":"Password must be included"}),403
     if len(password) < 8:
-        return jsonify({'Sorry', 'Password lenth must be more than 8 characters'}),403
+        return jsonify({'Sorry': 'Password lenth must be more than 8 characters'}),403
     #check correct emai
     bad_email = re.match('^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$', email)    
     if bad_email == None:

--- a/app/events_blueprint/models.py
+++ b/app/events_blueprint/models.py
@@ -34,7 +34,7 @@ class Events(db.Model):
         db.session.commit()
 
     def __repr__(self):
-        return "<Event: {}>".format(self.name) #object instance of the model whenever it is queried
+        return "<Event: {}>".format(self.eventid) #object instance of the model whenever it is queried
 
     def __init__(self, name, user_public_id, cost,location,date,description,category):        
         self.name = name

--- a/app/events_blueprint/views.py
+++ b/app/events_blueprint/views.py
@@ -59,17 +59,7 @@ def get_event(logged_in_user, eventid):
     response.status_code = 200
     return response
 
-def return_response(event):
-    response = jsonify({                
-                'name': event.name,
-                'cost': event.cost,                
-                'location': event.location,
-                'description': event.description,
-                'date' : event.date,
-                'category': event.category,
-                'date_created': event.date_created               
-            })
-    return response
+
 #get all events
 @events.route('/api/v1/events')
 @token_required
@@ -79,18 +69,8 @@ def get_all_events(logged_in_user):
     results = [] # a list of events
     for event in events:
         
-        obj = {
-            'id': event.eventid,
-            'name': event.name,
-            'cost': event.cost,
-            'public_userid': event.user_public_id, #fetch user details using this ID
-            'location': event.location,
-            'description': event.description,
-            'date' : event.date,
-            'category': event.category,
-            'date_created': event.date_created,
-            'date_modified': event.date_modified
-        }
+        obj = return_obj(event)
+
         results.append(obj)
     response = jsonify(results)
     response.status_code = 200
@@ -140,9 +120,18 @@ def searc_by_location(logged_in_user, location):
     event_searched = models.Events.query.filter_by(location=location)
     if event_searched:
         results = [] # a list of events
-        for event in events:
+        for event in event_searched:
 
-            obj = {
+            obj =return_obj(event)
+
+            results.append(obj)
+        response = jsonify(results)
+        response.status_code = 200
+        return response    
+    return jsonify({'Not found':'No event in that location'}),404
+
+def return_obj(event):
+    obj =  {
                 'id': event.eventid,
                 'name': event.name,
                 'cost': event.cost,
@@ -154,11 +143,20 @@ def searc_by_location(logged_in_user, location):
                 'date_created': event.date_created,
                 'date_modified': event.date_modified
             }
-            results.append(obj)
-        response = jsonify(results)
-        response.status_code = 200
-        return response    
-    return jsonify({'Not found':'No event in that location'}),404
+    return obj
+
+def return_response(event):
+    response = jsonify({                
+                'name': event.name,
+                'cost': event.cost,                
+                'location': event.location,
+                'description': event.description,
+                'date' : event.date,
+                'category': event.category,
+                'date_created': event.date_created               
+            })
+    return response
+
 
 #rsvp or respond to an event (attending/not attending/maybe)
 @events.route('/api/v1/events/<int:eventid>/rsvp', methods=['POST'])

--- a/app/events_blueprint/views.py
+++ b/app/events_blueprint/views.py
@@ -55,21 +55,21 @@ def get_event(logged_in_user, eventid):
     event = models.Events.query.filter_by(eventid=eventid).first()
     if not event:
         return jsonify({'Not found':'Event with that id is not available'}),404
-    response = jsonify({
-                'id': event.eventid,
+    response = return_response(event)
+    response.status_code = 200
+    return response
+
+def return_response(event):
+    response = jsonify({                
                 'name': event.name,
-                'cost': event.cost,
-                'public_userid': event.user_public_id, #fetch user details using this ID
+                'cost': event.cost,                
                 'location': event.location,
                 'description': event.description,
                 'date' : event.date,
                 'category': event.category,
-                'date_created': event.date_created,
-                'date_modified': event.date_modified
+                'date_created': event.date_created               
             })
-    response.status_code = 200
     return response
-
 #get all events
 @events.route('/api/v1/events')
 @token_required
@@ -108,8 +108,6 @@ def delete_event(logged_in_user, eventid):
     if event.user_public_id != logged_in_user.public_id:
         return jsonify({'Authorization error':'You can only delete your own event'}),401
 
-    import pdb; pdb.set_trace()
-
     event.delete()
     return jsonify({"message": "Event {} deleted successfully".format(event.eventid)}), 200
 
@@ -131,14 +129,7 @@ def edit_event(logged_in_user,eventid):
     event.cost = request.json.get('cost', event.cost)
     event.save()
 
-    response = jsonify({                        
-                    'name': event.name,
-                    'cost': event.cost,                     
-                    'location': event.location,
-                    'description': event.description,
-                    'date' : event.date,
-                    'category': event.category                   
-            })
+    response = return_response(event)
     response.status_code = 201
     return response
 

--- a/app/events_blueprint/views.py
+++ b/app/events_blueprint/views.py
@@ -124,7 +124,7 @@ def edit_event(logged_in_user,eventid):
         abort(403)
     if event.user_public_id != logged_in_user.public_id:
         return jsonify({'Authorization error':'You can only update your own event'}), 401
-    
+
     event.name = request.json.get('name', event.name) #if no changes made let the initial remain
     event.description = request.json.get('description', event.description)
     event.location = request.json.get('location', event.location)
@@ -140,9 +140,7 @@ def edit_event(logged_in_user,eventid):
                     'location': event.location,
                     'description': event.description,
                     'date' : event.date,
-                    'category': event.category,
-                    'date_created': event.date_created,
-                    'date_modified': event.date_modified
+                    'category': event.category                   
             })
     response.status_code = 201
     return response

--- a/app/events_blueprint/views.py
+++ b/app/events_blueprint/views.py
@@ -101,17 +101,17 @@ def get_all_events(logged_in_user):
 @token_required
 def delete_event(logged_in_user, eventid):
     # retrieve a event using its ID
-    event = models.Events.query.filter_by(eventid=eventid).first()    
+    event = models.Events.query.filter_by(eventid=eventid).first()
     if not event:
         return jsonify({'Not found':'Event with that id is not available'}),404
 
     # if event.user_public_id != logged_in_user.public_id:
     #     return jsonify({'Authorization error':'You can only delete your own event'}),401
 
+    import pdb; pdb.set_trace()
+
     event.delete()
-    return {
-            "message": "Event {} deleted successfully".format(event.eventid) 
-         }, 201
+    return jsonify({"message": "Event {} deleted successfully".format(event.eventid)}), 200
 
 #edit and event
 @events.route('/api/v1/events/<int:eventid>', methods=['PUT'])

--- a/app/events_blueprint/views.py
+++ b/app/events_blueprint/views.py
@@ -105,8 +105,8 @@ def delete_event(logged_in_user, eventid):
     if not event:
         return jsonify({'Not found':'Event with that id is not available'}),404
 
-    # if event.user_public_id != logged_in_user.public_id:
-    #     return jsonify({'Authorization error':'You can only delete your own event'}),401
+    if event.user_public_id != logged_in_user.public_id:
+        return jsonify({'Authorization error':'You can only delete your own event'}),401
 
     import pdb; pdb.set_trace()
 

--- a/app/events_blueprint/views.py
+++ b/app/events_blueprint/views.py
@@ -120,8 +120,7 @@ def edit_event(logged_in_user,eventid):
     event = models.Events.query.filter_by(eventid=eventid).first()
     if not event:
         return jsonify({'Not found':'Event with that id is not available'}),404
-    if not request.json:
-        abort(403)
+   
     if event.user_public_id != logged_in_user.public_id:
         return jsonify({'Authorization error':'You can only update your own event'}), 401
 
@@ -132,11 +131,9 @@ def edit_event(logged_in_user,eventid):
     event.cost = request.json.get('cost', event.cost)
     event.save()
 
-    response = jsonify({
-                'id': event.eventid,
+    response = jsonify({                        
                     'name': event.name,
-                    'cost': event.cost, 
-                    'public_userid': event.user_public_id, #fetch user details using this ID
+                    'cost': event.cost,                     
                     'location': event.location,
                     'description': event.description,
                     'date' : event.date,


### PR DESCRIPTION
**What does this PR do?**

Implements feedback given by learning facilitator during defenses.

**Descriptions of task completed**

- Fixes the delete endpoint for events
- Implements access control. User can only delete or update own event
- Puts restriction on password length upon user registration

**How should this be manually tested**
To test clone the repo and run the app
` python run.py`
For event deletion login to get user access token with following endpoint using postman
`http://localhost:5000/api/v1/auth/login`

Using the delete endpoint `http://localhost:5000/api/v1/events/<eventid>` try to delete an event

**Related stories**

[154648234](https://www.pivotaltracker.com/story/show/154648234)

see screenshots below

**Screenshots**

![delete](https://user-images.githubusercontent.com/13331207/35429385-e0b09234-0284-11e8-9ed8-6c9158066578.PNG)
![accesscontrol](https://user-images.githubusercontent.com/13331207/35429403-f064ac56-0284-11e8-9ce6-4280ec4e7e5b.PNG)
![passwdlength](https://user-images.githubusercontent.com/13331207/35429418-fd414d9e-0284-11e8-96eb-dc8c887302e8.PNG)


